### PR TITLE
Add onboarding and media overview recipes

### DIFF
--- a/lib/cookbook_web/live/recipes/media_overview_live.ex
+++ b/lib/cookbook_web/live/recipes/media_overview_live.ex
@@ -1,0 +1,12 @@
+defmodule CookbookWeb.MediaOverviewLive do
+  use CookbookWeb, :live_view
+  use CookbookNative, :live_view
+
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  def render(assigns) do
+    ~H""
+  end
+end

--- a/lib/cookbook_web/live/recipes/media_overview_live.swiftui.ex
+++ b/lib/cookbook_web/live/recipes/media_overview_live.swiftui.ex
@@ -1,0 +1,79 @@
+defmodule CookbookWeb.MediaOverviewLive.SwiftUI do
+  use CookbookNative, [:render_component, format: :swiftui]
+
+  def render(assigns, _interface) do
+    ~LVN"""
+    <List style="listStyle(.plain); ignoresSafeArea(edges: .top); toolbarBackground(.hidden, for: .navigationBar); navigationBarBackButtonHidden(true); toolbar(content: :toolbar)">
+      <%!-- back button --%>
+      <%!-- TODO: add action to go back on button press --%>
+      <ToolbarItem template="toolbar" placement="topBarLeading">
+        <.button style="buttonStyle(.bordereless); tint(.primary);">
+          <Image
+            systemName="chevron.backward"
+            style="font(.caption); bold(); frame(width: 28, height: 28); background(.bar, in: .circle);"
+          />
+        </.button>
+      </ToolbarItem>
+      <ToolbarItem template="toolbar" placement="topBarTrailing">
+        <.button style="buttonStyle(.bordereless); tint(.primary);">
+          <Image
+            systemName="plus"
+            style="font(.caption); bold(); frame(width: 28, height: 28); background(.bar, in: .circle);"
+          />
+        </.button>
+      </ToolbarItem>
+      <%!-- cover row --%>
+      <VStack
+        style="background(content: :background); foregroundStyle(.white); listRowInsets(EdgeInsets());"
+      >
+        <%!-- album art space --%>
+        <Spacer style="aspectRatio(1, contentMode: .fit);" />
+
+        <VStack style="padding(); frame(maxWidth: .infinity); background(content: :background);">
+          <%!-- title --%>
+          <Text style="font(.title); bold();">Album</Text>
+          <Text style="font(.title2);">Artist</Text>
+          <Text style="font(.caption); bold(); foregroundStyle(.regularMaterial);">Genre · Year · Metadata</Text>
+
+          <%!-- actions --%>
+          <HStack style="padding(.vertical, 8); tint(.white); buttonStyle(.borderedProminent); controlSize(.large);">
+            <.button>
+              <Label systemImage="play.fill" style="foregroundStyle(.black); bold(); frame(maxWidth: .infinity);">Play</Label>
+            </.button>
+            <.button>
+              <Label systemImage="shuffle" style="foregroundStyle(.black); bold(); frame(maxWidth: .infinity);">Shuffle</Label>
+            </.button>
+          </HStack>
+
+          <%!-- description --%>
+          <Text style="font(.footnote); foregroundStyle(.thickMaterial); lineLimit(2);">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris magna leo, lacinia ut faucibus quis, sodales eget ex. Aenean et metus euismod, luctus nunc at, lobortis nunc.</Text>
+
+          <%!-- background blur --%>
+          <Rectangle
+            template="background"
+            style="fill(.thinMaterial); mask(mask: :mask)"
+          >
+            <Rectangle
+              template="mask"
+              style="fill(.linearGradient(colors: [.black.opacity(0), .black], startPoint: .top, endPoint: .bottom))"
+            />
+          </Rectangle>
+        </VStack>
+
+        <%!-- background image --%>
+        <Rectangle template="background" style="fill(.linearGradient(colors: [.orange, .red], startPoint: .topLeading, endPoint: .bottomTrailing)); ignoresSafeArea();" />
+      </VStack>
+
+      <%!-- track list --%>
+      <.button
+        :for={track <- 1..15}
+      >
+        <Label>
+          <Text template="icon" style="foregroundStyle(.secondary)"><%= track %></Text>
+          <Text template="title">Track <%= track %></Text>
+        </Label>
+      </.button>
+    </List>
+    """
+  end
+end

--- a/lib/cookbook_web/live/recipes/onboarding_live.ex
+++ b/lib/cookbook_web/live/recipes/onboarding_live.ex
@@ -1,0 +1,12 @@
+defmodule CookbookWeb.OnboardingLive do
+  use CookbookWeb, :live_view
+  use CookbookNative, :live_view
+
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  def render(assigns) do
+    ~H""
+  end
+end

--- a/lib/cookbook_web/live/recipes/onboarding_live.swiftui.ex
+++ b/lib/cookbook_web/live/recipes/onboarding_live.swiftui.ex
@@ -1,0 +1,56 @@
+defmodule CookbookWeb.OnboardingLive.SwiftUI do
+  use CookbookNative, [:render_component, format: :swiftui]
+
+  def render(assigns) do
+    ~LVN"""
+    <VStack style="padding();" spacing={32}>
+      <Text style="font(.largeTitle); bold();">What's New</Text>
+      <Grid alignment="leading" horizontalSpacing={16} verticalSpacing={16}>
+        <.feature
+          name="Onboarding"
+          icon="wand.and.sparkles"
+          description="See how to make a system-styled What's New screen."
+        />
+        <.feature
+          name="Maps"
+          icon="mappin.and.ellipse"
+          description="Use the MapKit addon to create interactive maps."
+          style="foregroundStyle(.red);"
+        />
+        <.feature
+          name="Charts"
+          icon="chart.line.uptrend.xyaxis"
+          description="Plot data on various charts with the Swift Charts addon"
+          style="foregroundStyle(.purple);"
+        />
+      </Grid>
+      <Spacer />
+      <Button style="buttonStyle(.borderedProminent); controlSize(.large);">
+        <Text style="frame(maxWidth: .infinity);">Continue</Text>
+      </Button>
+    </VStack>
+    """
+  end
+
+  attr :icon, :string
+  attr :name, :string
+  attr :description, :string
+  attr :rest, :global
+
+  def feature(assigns) do
+    ~LVN"""
+    <GridRow>
+      <Group style="foregroundStyle(.tint); font(.largeTitle); symbolRenderingMode(.hierarchical);">
+        <Image
+          systemName={@icon}
+          {@rest}
+        />
+      </Group>
+      <VStack alignment="leading" style="font(.subheadline);">
+        <Text style="bold();"><%= @name %></Text>
+        <Text style="foregroundStyle(.secondary);"><%= @description %></Text>
+      </VStack>
+    </GridRow>
+    """
+  end
+end

--- a/lib/cookbook_web/router.ex
+++ b/lib/cookbook_web/router.ex
@@ -61,10 +61,22 @@ defmodule CookbookWeb.Router do
         description: "MapKit addon library",
         category: "Addons"
       }
+      live "/media-overview", MediaOverviewLive, metadata: %{
+        title: "Media Overview",
+        icon: "play.square.stack",
+        description: "Apple Music/Podcasts-styled album overview",
+        category: "UI"
+      }
       live "/message-thread", MessageThreadLive, metadata: %{
         title: "Message Thread",
         icon: "message.fill",
         description: "A list of message bubbles that starts at the bottom",
+        category: "UI"
+      }
+      live "/onboarding", OnboardingLive, metadata: %{
+        title: "Onboarding",
+        icon: "list.star",
+        description: "A list of features available in the app",
         category: "UI"
       }
       live "/playback-bar", PlaybackBarLive, metadata: %{


### PR DESCRIPTION
This adds 2 new recipes for common interfaces:

<img src=https://github.com/user-attachments/assets/0fd7d4df-8d7a-4c7b-8ae0-f09e0e76e1a7 width=300 />

<img src=https://github.com/user-attachments/assets/cc065da4-0573-46c2-b9e3-712c79851d0e width=300 />
