### PR TITLE
fix: back button in media overview navigates to main list

### DIFF
--- a/lib/cookbook_web/live/cookbook_live.swiftui.ex
+++ b/lib/cookbook_web/live/cookbook_live.swiftui.ex
@@ -10,7 +10,8 @@ defmodule CookbookWeb.CookbookLive.SwiftUI do
       style={[
         "listStyle(.plain)",
         ~s[navigationTitle("Cookbook")],
-        "toolbar(content: :toolbar)"
+        "toolbar(content: :toolbar)",
+        "navigationBarBackButtonHidden(true);"
       ]}
     >
       <ToolbarItem template="toolbar">

--- a/lib/cookbook_web/live/recipes/media_overview_live.swiftui.ex
+++ b/lib/cookbook_web/live/recipes/media_overview_live.swiftui.ex
@@ -7,12 +7,12 @@ defmodule CookbookWeb.MediaOverviewLive.SwiftUI do
       <%!-- back button --%>
       <%!-- TODO: add action to go back on button press --%>
       <ToolbarItem template="toolbar" placement="topBarLeading">
-        <.button style="buttonStyle(.bordereless); tint(.primary);">
+        <.link navigate="/" style="buttonStyle(.bordereless); tint(.primary);">
           <Image
             systemName="chevron.backward"
             style="font(.caption); bold(); frame(width: 28, height: 28); background(.bar, in: .circle);"
           />
-        </.button>
+        </.link>
       </ToolbarItem>
       <ToolbarItem template="toolbar" placement="topBarTrailing">
         <.button style="buttonStyle(.bordereless); tint(.primary);">


### PR DESCRIPTION
### **Pull Request Description**

**Title:**
Fix back button in the media overview section

**Description:**
This PR resolves an issue where the back button in the media overview section does not navigate back to the main list as expected. The fix ensures that the button correctly directs the user to the main list page.

**Changes:**
    - Updated navigation logic for the back button in the media overview section.
    - Added navigationBarBackButtonHidden in the main list to properly handle navigation.

**Testing:**
    1. Navigate to the media overview section.
    2. Click the back button.
    3. Confirm that the user is redirected to the main list.